### PR TITLE
Fix the build failed issue while cloning the repository

### DIFF
--- a/{{ cookiecutter.repo_name }}/.gitignore
+++ b/{{ cookiecutter.repo_name }}/.gitignore
@@ -268,9 +268,6 @@ fabric.properties
 
 !/gradle/wrapper/gradle-wrapper.jar
 
-# Settings
-settings/
-
 !/app/src/production
 
 # End of https://www.toptal.com/developers/gitignore/api/android,androidstudio,kotlin,java,gradle,git


### PR DESCRIPTION
The settings folder was in the` .gitignore `file, so when pushing the app the settings folder was not getting uploaded in Git Hub which is causing the issue while cloning the repo because the static code analysis was missing.